### PR TITLE
Update REPL based on `asyncio.__main__` in CPython 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Combine these with `-i` to open a REPL after running the file specified on the c
 
 See `import-expression --help` for more details.
 
+The REPL requires Python 3.10+.
+
 ### Running a file
 
 Run `import-expression <filename.py>`.

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -1,4 +1,5 @@
 # Copyright © io mintz <io@mintz.cc>
+# Copyright © Thanos <111999343+Sachaa-Thanasius@users.noreply.github.com>
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”),

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -49,13 +49,7 @@ from import_expression import constants
 
 features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
 
-try:
-	from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
-except ImportError:
-	SUPPORTS_ASYNCIO_REPL = False
-else:
-	SUPPORTS_ASYNCIO_REPL = True
-
+from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
 
 class ImportExpressionCommandCompiler(codeop.CommandCompiler):
 	def __init__(self):
@@ -283,10 +277,6 @@ def main():
 	}
 
 	args = parse_args()
-
-	if args.asyncio and not SUPPORTS_ASYNCIO_REPL:
-		print('Python3.8+ required for the AsyncIO REPL.', file=sys.stderr)
-		sys.exit(2)
 
 	prelude = None
 	if args.filename:

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -45,13 +45,6 @@ from codeop import PyCF_DONT_IMPLY_DEDENT, PyCF_ALLOW_INCOMPLETE_INPUT
 import import_expression
 from import_expression import constants
 
-if os.path.basename(sys.argv[0]) == 'import_expression':
-	import warnings
-	warnings.warn(UserWarning(
-		'The import_expression alias is deprecated, and will be removed in v2.0. '
-		'Please use import-expression (with a hyphen) instead.'
-	))
-
 features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
 
 try:

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -43,10 +43,16 @@ import types
 import warnings
 from asyncio import futures
 from codeop import PyCF_DONT_IMPLY_DEDENT, PyCF_ALLOW_INCOMPLETE_INPUT
-from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
 
 import import_expression
 from import_expression import constants
+
+try:
+	from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
+except ImportError:
+	SUPPORTS_ASYNCIO_REPL = False
+else:
+	SUPPORTS_ASYNCIO_REPL = True
 
 features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
 

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -279,7 +279,6 @@ def main():
 
 	args = parse_args()
 
-	prelude = None
 	if args.filename:
 		with open(args.filename) as f:
 			flags = 0
@@ -287,9 +286,12 @@ def main():
 				flags |= PyCF_ALLOW_TOP_LEVEL_AWAIT
 			prelude = import_expression.compile(f.read(), flags=flags)
 		if args.asyncio:
-			# we need a new loop because using asyncio.run here breaks the console
-			loop = asyncio.new_event_loop()
-			loop.run_until_complete(eval(prelude, repl_locals))
+			prelude_result = eval(prelude, repl_locals)
+			# if there are no top level awaits in the code, eval will not return a coroutine
+			if inspect.isawaitable(prelude_result):
+				# we need a new loop because using asyncio.run here breaks the console
+				loop = asyncio.new_event_loop()
+				loop.run_until_complete(prelude_result)
 		else:
 			import_expression.exec(prelude, globals=repl_locals)
 		if not args.interactive:

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -47,6 +47,8 @@ from codeop import PyCF_DONT_IMPLY_DEDENT, PyCF_ALLOW_INCOMPLETE_INPUT
 import import_expression
 from import_expression import constants
 
+features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
+
 try:
 	from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
 except ImportError:
@@ -54,7 +56,6 @@ except ImportError:
 else:
 	SUPPORTS_ASYNCIO_REPL = True
 
-features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
 
 class ImportExpressionCommandCompiler(codeop.CommandCompiler):
 	def __init__(self):

--- a/import_expression/__main__.py
+++ b/import_expression/__main__.py
@@ -41,18 +41,12 @@ import types
 import warnings
 from asyncio import futures
 from codeop import PyCF_DONT_IMPLY_DEDENT, PyCF_ALLOW_INCOMPLETE_INPUT
+from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
 
 import import_expression
 from import_expression import constants
 
 features = [getattr(__future__, fname) for fname in __future__.all_feature_names]
-
-try:
-	from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
-except ImportError:
-	SUPPORTS_ASYNCIO_REPL = False
-else:
-	SUPPORTS_ASYNCIO_REPL = True
 
 class ImportExpressionCommandCompiler(codeop.CommandCompiler):
 	def __init__(self):


### PR DESCRIPTION
Technically, more could've been done, but I tried to make the diff minimal for this PR. Some changes include:
- Adding a return code and keeping it updated so that the REPL can return non-0 values on failure.
- Running the python startup file before the REPL starts (for better emulation of the actual REPL).
- Other tidbits (can be enumerated if need be).

Some notes:
- At the moment, this does not try to remove support for <3.8.
- This explicitly avoids using `_pyrepl` because it isn't stable yet and doesn't have a public API.